### PR TITLE
Fix greedy regex

### DIFF
--- a/monolog.json
+++ b/monolog.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/Seldaek/monolog",
     "regex": {
       "default": {
-        "pattern": "\\[(?P<timestamp>.*)\\] (?P<logger>\\w+).(?P<level>\\w+): (?P<body>[^\\[]+) (?P<context>[\\[\\{].*[\\]\\}]) (?P<extra>[\\[\\{].*[\\]\\}])"
+        "pattern": "\\[(?P<timestamp>.*?)\\] (?P<logger>\\w+).(?P<level>\\w+): (?P<body>[^\\[]+) (?P<context>[\\[\\{].*[\\]\\}]) (?P<extra>[\\[\\{].*[\\]\\}])"
       }
     },
     "level-field" : "level",


### PR DESCRIPTION
a greedy implementation fails in this case:

```[2025-05-06T12:03:03.891667+02:00] request.CRITICAL: Task failed: Handling "****Task" failed: [https://someurl] Client error: `GET https://someurl` resulted in a `404 Not Found` response: <!DOCTYPE html> <html lang="de" (truncated...)  [] []```
https://regex101.com/r/1TNR17/1


because the timestamp mark is extended to the closing bracket of the exception details. Making the timestamp match ungreedy seems to be the more correct way to go.